### PR TITLE
Allow database access by Postgres admin user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ WORKDIR project
 # install.sh uses sed inplace to modify the files used to setup the database.
 # However, sed will throw a permissioning error as the user is not root.
 RUN chmod a+w /project/data/
-RUN sed -i -e 's/all all all/all docker all/g' /usr/local/bin/docker-entrypoint.sh
+RUN /usr/local/bin/docker-entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ You will setup a few configuration values before getting things going. They are:
 * `DB_USER`: username to access the database
 * `DB_PASSWORD`: password of the user
 * `PORT`: The port used by the database
-* `POSTGRES_PASSWORD`: password for admin account (not important as it's not used but can't be empty)
+* `POSTGRES_PASSWORD`: password for admin account
 
 You need to create a file called `.config` in the project's root directory. An example of `.config` is shown in `.config.template`. It contains a set of defaults and you can just copy over `.config.template` to `.config`.
 


### PR DESCRIPTION
This also allows the read-only username to be something other than
docker. The last RUN with sed in the Dockerfile only allowed access by
a username with the name of docker