### PR TITLE
Support locking database to everyone but DB_USER

### DIFF
--- a/.config.template
+++ b/.config.template
@@ -3,3 +3,4 @@ export DB_USER=docker
 export DB_PASSWORD=docker
 export POSTGRES_PASSWORD=postgres
 export READ_ONLY=true
+export LOCK_DB=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,13 @@ RUN make prepare-csv
 # Setup database
 FROM postgres
 
+WORKDIR project
 COPY --from=builder /project/data/*.csv /project/data/
 COPY bin/install.sh /docker-entrypoint-initdb.d/
 COPY sql/*.sql /project/data/
 COPY .config /project/
-WORKDIR project
+COPY bin/pre-install.sh /project/data/
+RUN /project/data/pre-install.sh
 
 # install.sh uses sed inplace to modify the files used to setup the database.
 # However, sed will throw a permissioning error as the user is not root.

--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,4 @@ include make/data.mk
 test:
 	test/test-db
 	test/test-read-only
+	test/test-lock

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ You will setup a few configuration values before getting things going. They are:
 * `PORT`: The port used by the database
 * `POSTGRES_PASSWORD`: password for admin account
 * `READ_ONLY`: set to `true` to prevent `DB_USER` from creating new tables
+* `LOCK_DB`: set to `true` to lock everyone but `DB_USER` from accessing the database
 
 You need to create a file called `.config` in the project's root directory. An example of `.config` is shown in `.config.template`. It contains a set of defaults and you can just copy over `.config.template` to `.config`.
 
@@ -28,7 +29,13 @@ From the localhost, you can connect to the database using:
 as running `bin/construct-url` returns the database URL by using the values set in `.config`. In general the database URL is `postgresql://<DB_USER>:<DB_PASSWORD>@localhost:<PORT>/wells`.
 
 ## Testing
-Calling `make test` will test that the database is running, that all the tables are accessible, and `DB_USER` is read only. You can run the tests individually by running `test/test-db` and `test/test-read-only`. Note, the latter will fail if `READ_ONLY` was not set to `true`.
+Calling `make test` will run the following tests:
+
+* `test/test-db`: the database is running and tables are accessible
+* `test/test-read-only`: `DB_USER` is read only (will fail if `READ_ONLY` was not set to `true`)
+* `test/test-lock`: the database is locked for everyone but `DB_USER` (will fail if `DB_LOCK` was not set to `true`)
+
+You can run the tests individually, too. E.g., `test/test-db`.
 
 ## License
 This project is distributed under the GNU General Purpose License. Please see `COPYING` for more information.

--- a/bin/construct-url
+++ b/bin/construct-url
@@ -3,4 +3,8 @@ set -eu
 
 source .config
 
-echo "postgresql://$DB_USER:$DB_PASSWORD@localhost:$PORT/wells"
+if [[ $# -eq 1 && $1 == '--admin' ]]; then
+    echo "postgresql://postgres:$POSTGRES_PASSWORD@localhost:$PORT/wells"
+else
+    echo "postgresql://$DB_USER:$DB_PASSWORD@localhost:$PORT/wells"
+fi

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -5,23 +5,14 @@ source .config
 export POSTGRES_USER=postgres
 DB_NAME=wells
 
-set_config() {
-    sed -i "s/DB_USER/$DB_USER/" data/create_user.sql
-    sed -i "s/DB_PASSWORD/$DB_PASSWORD/" data/create_user.sql
-}
-
-setup_db() {
+main() {
     psql -c "CREATE DATABASE $DB_NAME;"
     psql -d $DB_NAME -f data/create_db.sql
     if [[ $READ_ONLY == true ]]; then
+        echo "Making $DB_USER read only..."
 	psql -d $DB_NAME -c "REVOKE CREATE ON SCHEMA public FROM public;"
     fi
     psql -d $DB_NAME -f data/create_user.sql
-}
-
-main() {
-    set_config
-    setup_db
 }
 
 

--- a/bin/pre-install.sh
+++ b/bin/pre-install.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Pre-install tasks to run before calling the entry point script.
+set -eu
+
+source .config
+
+lock_db() {
+    if [[ $LOCK_DB == true ]]; then
+	echo "Locking admin account..."
+	sed -i "s/all all all/all $DB_USER all/g" /usr/local/bin/docker-entrypoint.sh
+    fi
+}
+
+set_config() {
+    sed -i "s/DB_USER/$DB_USER/" data/create_user.sql
+    sed -i "s/DB_PASSWORD/$DB_PASSWORD/" data/create_user.sql
+}
+
+main() {
+    lock_db
+    set_config
+}
+
+
+main

--- a/test/test-lock
+++ b/test/test-lock
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Attempt to access the database with the postgres admin account.
+set -eu
+
+source .config
+
+list_tables() {
+    psql -l $(bin/construct-url --admin)
+}
+
+main() {
+    local message
+    message=$(list_tables 2>&1) || : # having || : let's us use set -eu
+
+    if echo $message | grep -q "no pg_hba.conf entry"; then
+	echo "postgres user cannot access database (as expected)!"
+    else
+	echo "Failed to prevent locking the database"
+    fi
+}
+
+
+main


### PR DESCRIPTION
* Create a pre-install script to lock database
* Move setting configuration to pre-install script
* Run pre-install script when building Docker image
* Add LOCK_DB to config template
* Add option for returning databse URL for postgres admin account
* Add test/test-lock
* Add test-lock to the Makefile's test rule
* Update README